### PR TITLE
Publish Android to Open Testing track on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,7 @@ jobs:
     needs: extract-version
     uses: ./.github/workflows/template-android-build-and-publish.yml
     with:
-      destination: alpha
+      destination: beta
       version: ${{ needs.extract-version.outputs.version }}
     secrets: inherit
 


### PR DESCRIPTION
## Summary
- Changes Android release destination from `alpha` to `beta` track, which corresponds to Google Play's Open Testing

## Test plan
- [ ] Tag a new release and verify the Android build is published to the Open Testing track in Google Play Console

🤖 Generated with [Claude Code](https://claude.com/claude-code)